### PR TITLE
seo: improve Kaffee und Kuchen title and meta for search intent

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -93,60 +93,66 @@
         {
           "@type": "ListItem",
           "position": 1,
-          "url": "https://germanbakingasheville.com/blog/german-birthday-cakes.html"
+          "url": "https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html"
         },
         
         {
           "@type": "ListItem",
           "position": 2,
-          "url": "https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
+          "url": "https://germanbakingasheville.com/blog/german-birthday-cakes.html"
         },
         
         {
           "@type": "ListItem",
           "position": 3,
-          "url": "https://germanbakingasheville.com/blog/bakery-lightning-talk-scipy-2026.html"
+          "url": "https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
         },
         
         {
           "@type": "ListItem",
           "position": 4,
-          "url": "https://germanbakingasheville.com/blog/six-months-at-market-asheville-home.html"
+          "url": "https://germanbakingasheville.com/blog/bakery-lightning-talk-scipy-2026.html"
         },
         
         {
           "@type": "ListItem",
           "position": 5,
-          "url": "https://germanbakingasheville.com/blog/meet-wright-open-source-engine.html"
+          "url": "https://germanbakingasheville.com/blog/six-months-at-market-asheville-home.html"
         },
         
         {
           "@type": "ListItem",
           "position": 6,
-          "url": "https://germanbakingasheville.com/blog/custom-cake-orders.html"
+          "url": "https://germanbakingasheville.com/blog/meet-wright-open-source-engine.html"
         },
         
         {
           "@type": "ListItem",
           "position": 7,
-          "url": "https://germanbakingasheville.com/blog/automated-grocery-lists.html"
+          "url": "https://germanbakingasheville.com/blog/custom-cake-orders.html"
         },
         
         {
           "@type": "ListItem",
           "position": 8,
-          "url": "https://germanbakingasheville.com/blog/how-north-asheville-market-started-our-bakery.html"
+          "url": "https://germanbakingasheville.com/blog/automated-grocery-lists.html"
         },
         
         {
           "@type": "ListItem",
           "position": 9,
-          "url": "https://germanbakingasheville.com/blog/why-we-make-vanilla-sugar-and-pudding-powder.html"
+          "url": "https://germanbakingasheville.com/blog/how-north-asheville-market-started-our-bakery.html"
         },
         
         {
           "@type": "ListItem",
           "position": 10,
+          "url": "https://germanbakingasheville.com/blog/why-we-make-vanilla-sugar-and-pudding-powder.html"
+        },
+        
+        {
+          "@type": "ListItem",
+          "position": 11,
           "url": "https://germanbakingasheville.com/blog/what-is-quark.html"
         }
         
@@ -198,6 +204,25 @@
             <div class="blog-grid">
               
                 <article class="blog-card">
+  <a href="why-we-dont-make-everything-gluten-free.html" class="blog-card__link">
+    
+    <div class="blog-card__content">
+      <div class="blog-card__meta">
+        <time class="blog-card__date" datetime="2026-08-09">August 09, 2026</time>
+        
+          <span class="blog-card__separator">·</span>
+          <span class="blog-card__author">Mary</span>
+        
+        <span class="blog-card__separator">·</span>
+        <span class="blog-card__reading-time">3 min read</span>
+      </div>
+      <h2 class="blog-card__title">Why We Don&#39;t Make Everything Gluten-Free</h2>
+      <p class="blog-card__excerpt">Some of our cakes are gluten-free and some are not. That is a choice. We will not compromise what makes a German cake good just to put a label on it.</p>
+    </div>
+  </a>
+</article>
+              
+                <article class="blog-card">
   <a href="german-birthday-cakes.html" class="blog-card__link">
     
     <div class="blog-card__content">
@@ -223,7 +248,7 @@
         <picture>
           <source srcset="../images/3pm-german-baking-68.jpg" type="image/webp">
           <img src="../images/3pm-german-baking-68.jpg"
-               alt="Why 3pm? The Kaffee und Kuchen Tradition Behind Our Name"
+               alt="Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)"
                loading="lazy"
                width="800"
                height="533">
@@ -240,8 +265,8 @@
         <span class="blog-card__separator">·</span>
         <span class="blog-card__reading-time">2 min read</span>
       </div>
-      <h2 class="blog-card__title">Why 3pm? The Kaffee und Kuchen Tradition Behind Our Name</h2>
-      <p class="blog-card__excerpt">Our bakery is named 3pm German Baking. There is a reason for that, it marks the time of Kaffee und Kuchen, the German coffee and cake tradition that most Americans have never heard of.</p>
+      <h2 class="blog-card__title">Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)</h2>
+      <p class="blog-card__excerpt">Kaffee und Kuchen is the German afternoon tradition of coffee and cake — a daily ritual at 3pm that most Americans have never heard of. It&#39;s why our bakery is named 3pm, and it shaped the lighter, less-sweet style of German baking.</p>
     </div>
   </a>
 </article>

--- a/blog/why-we-dont-make-everything-gluten-free.html
+++ b/blog/why-we-dont-make-everything-gluten-free.html
@@ -13,18 +13,18 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="What is Kaffee und Kuchen? Learn about the German coffee-and-cake tradition, why 3pm is the time for it, and how it shaped the lighter style of German baking at 3pm German Baking in Asheville, NC.">
-  <meta name="author" content="William">
+  <meta name="description" content="Why aren&#39;t all cakes at 3pm German Baking in Asheville, NC gluten-free? Learn how we keep things hand-made and small-batch, why our apple strudel is vegan instead, and which cake we still will not serve.">
+  <meta name="author" content="Mary">
   <meta name="robots" content="max-image-preview:large">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="3pm German Baking">
-  <meta property="og:title" content="Kaffee und Kuchen: The German Coffee and Cake Tradition | 3pm German Baking Blog">
-  <meta property="og:description" content="Kaffee und Kuchen is the German afternoon tradition of coffee and cake — a daily ritual at 3pm that most Americans have never heard of. It&#39;s why our bakery is named 3pm, and it shaped the lighter, less-sweet style of German baking.">
+  <meta property="og:title" content="Why We Don&#39;t Make Everything Gluten-Free | 3pm German Baking, Asheville, NC">
+  <meta property="og:description" content="Some of our cakes are gluten-free and some are not. That is a choice. We will not compromise what makes a German cake good just to put a label on it.">
   <meta property="og:url"
-        content="https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html">
+        content="https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html">
   
     <meta property="og:image"
-          content="https://germanbakingasheville.com/images/3pm-german-baking-68.jpg">
+          content="https://germanbakingasheville.com/images/logo.png">
   
   <meta property="og:image:width" content="400">
   <meta property="og:image:height" content="400">
@@ -32,27 +32,27 @@
         content="3pm German Baking — authentic German baking in Asheville, NC">
   <meta property="og:locale" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Kaffee und Kuchen: The German Coffee and Cake Tradition | 3pm German Baking Blog">
-  <meta name="twitter:description" content="Kaffee und Kuchen is the German afternoon tradition of coffee and cake — a daily ritual at 3pm that most Americans have never heard of. It&#39;s why our bakery is named 3pm, and it shaped the lighter, less-sweet style of German baking.">
+  <meta name="twitter:title" content="Why We Don&#39;t Make Everything Gluten-Free | 3pm German Baking, Asheville, NC">
+  <meta name="twitter:description" content="Some of our cakes are gluten-free and some are not. That is a choice. We will not compromise what makes a German cake good just to put a label on it.">
   
     <meta name="twitter:image"
-          content="https://germanbakingasheville.com/images/3pm-german-baking-68.jpg">
+          content="https://germanbakingasheville.com/images/logo.png">
   
   <meta name="twitter:image:alt"
         content="3pm German Baking — authentic German baking in Asheville, NC">
   <meta property="article:published_time"
-        content="2026-07-25T00:00:00-05:00">
+        content="2026-08-09T00:00:00-05:00">
   <meta property="article:modified_time"
-        content="2026-07-25T00:00:00-05:00">
-  <meta property="article:author" content="William">
+        content="2026-08-09T00:00:00-05:00">
+  <meta property="article:author" content="Mary">
   
   <link rel="canonical"
-        href="https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html">
+        href="https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html">
   <link rel="alternate"
         type="application/rss+xml"
         href="/feed.xml"
         title="3pm German Baking Blog">
-  <title>Kaffee und Kuchen: The German Coffee and Cake Tradition | 3pm German Baking Blog</title>
+  <title>Why We Don&#39;t Make Everything Gluten-Free | 3pm German Baking, Asheville, NC</title>
   <link rel="icon" type="image/png" href="../images/logo.png">
   <link rel="apple-touch-icon" href="../images/logo.png">
   <link rel="manifest" href="/manifest.json">
@@ -75,14 +75,14 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "inLanguage": "en-US",
-    "headline": "Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)",
-    "description": "Kaffee und Kuchen is the German afternoon tradition of coffee and cake \u2014 a daily ritual at 3pm that most Americans have never heard of. It\u0027s why our bakery is named 3pm, and it shaped the lighter, less-sweet style of German baking.",
-    "image": "https://germanbakingasheville.com/images/3pm-german-baking-68.jpg",
-    "datePublished": "2026-07-25T00:00:00-05:00",
-    "dateModified": "2026-07-25T00:00:00-05:00",
+    "headline": "Why We Don\u0027t Make Everything Gluten-Free",
+    "description": "Some of our cakes are gluten-free and some are not. That is a choice. We will not compromise what makes a German cake good just to put a label on it.",
+    "image": "https://germanbakingasheville.com/images/logo.png",
+    "datePublished": "2026-08-09T00:00:00-05:00",
+    "dateModified": "2026-08-09T00:00:00-05:00",
     "author": {
       "@type": "Person",
-      "name": "William",
+      "name": "Mary",
       "url": "https://germanbakingasheville.com/"
     },
     "publisher": {
@@ -98,10 +98,10 @@
     },
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": "https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
+      "@id": "https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html"
     }
     
-    ,"wordCount": 327
+    ,"wordCount": 428
     ,"contentLocation": {
       "@type": "Place",
       "name": "Asheville, North Carolina",
@@ -135,8 +135,8 @@
       {
         "@type": "ListItem",
         "position": 3,
-        "name": "Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)",
-        "item": "https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
+        "name": "Why We Don\u0027t Make Everything Gluten-Free",
+        "item": "https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html"
       }
     ]
   }
@@ -160,51 +160,40 @@
       <div class="container container--narrow">
         <article>
           <header class="blog-post__header">
-            <h1 class="blog-post__title">Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)</h1>
+            <h1 class="blog-post__title">Why We Don&#39;t Make Everything Gluten-Free</h1>
             <div class="blog-post__meta">
-              <time class="blog-post__date" datetime="2026-07-25">July 25, 2026</time>
+              <time class="blog-post__date" datetime="2026-08-09">August 09, 2026</time>
               <span class="blog-post__separator">·</span>
-              <span class="blog-post__author">William</span>
+              <span class="blog-post__author">Mary</span>
               <span class="blog-post__separator">·</span>
-              <span class="blog-post__reading-time">2 min read</span>
+              <span class="blog-post__reading-time">3 min read</span>
             </div>
             <div class="divider">
               <span class="divider__icon">✿</span>
             </div>
           </header>
           
-            <div class="blog-post__featured-image">
-              <picture>
-                <source srcset="../images/3pm-german-baking-68.jpg" type="image/webp">
-                <img src="../images/3pm-german-baking-68.jpg"
-                     alt="Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)"
-                     width="800"
-                     height="533"
-                     data-pin-description="What is Kaffee und Kuchen? Learn about the German coffee-and-cake tradition, why 3pm is the time for it, and how it shaped the lighter style of German baking at 3pm German Baking in Asheville, NC."
-                     data-pin-url="https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html">
-                <a class="blog-post__pin"
-                   href="https://pinterest.com/pin/create/button/?url=https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html&description=Kaffee%20und%20Kuchen%3A%20The%20German%20Coffee%20and%20Cake%20Tradition%20%28And%20Why%20Our%20Bakery%20Is%20Named%203pm%29&media=https://germanbakingasheville.com/images/3pm-german-baking-68.jpg"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   aria-label="Save to Pinterest">Save</a>
-              </picture>
-            </div>
-          
-          <div class="blog-post__content"><h2>A Thing You Notice</h2>
-<p>When I lived in Germany, I started noticing that cake was always on the display at cafés in the afternoon. Not for any special reason, just as a normal part of the day. At the time I did not think much about it, it was just how things were.</p>
-<h2>The Tradition</h2>
-<p>That timing has a name: <em>Kaffee und Kuchen</em>. Coffee and cake, every afternoon around 3pm. It is more of a daily rhythm for the older generation these days, but every German knows the association. No matter your age, you know that 3pm is when you might sit down for a slice of cake. It is not something everyone does every day anymore, but it is still part of the culture.</p>
-<h2>A Break, Not a Stop</h2>
-<p>The cakes themselves are part of why it works. German cakes are <a href="/blog/what-is-quark.html">lighter and less sweet</a> than their American counterparts. They are meant to be enjoyed <em>with</em> coffee, not as a heavy dessert that ends your afternoon. A slice and a cup of coffee, and you can go on with your day.</p>
-<p>We have heard this from our customers too, that our cakes do not weigh them down the way they expected. That comes from the tradition, the idea that cake is something you fit into your day, not something that ends it.</p>
-<h2>Why 3pm</h2>
-<p>Mary grew up with <em>Kaffee und Kuchen</em>. It is how she thinks about baking, everything is timed around that afternoon moment. When we were deciding on a name for the business, the time was already baked into how she operates. 3pm German Baking is not just a name. It tells you what we are about. You can find one of our lighter cakes at the West Asheville or Black Mountain farmers markets.</p>
-<p>If you want to try a lighter slice of cake with your coffee, <a href="/index.html#find-us">find us at a market</a> or <a href="mailto:info@germanbakingasheville.com">email us your order</a> and we will get you your cake.</p></div>
+          <div class="blog-post__content"><h2>The Question We Hear</h2>
+<p>Customers ask at the market whether our cakes are gluten-free. It is a fair question, and a lot of people in Asheville eat that way. The honest answer is that some of our cakes are and some are not.</p>
+<p>We have tried to make them all gluten-free. Some recipes translate and some do not. We will not force one just to put a label on it.</p>
+<h2>Made Like It Was in Grandma's Kitchen</h2>
+<p>We want everything we bake to feel hand-made and small-batch, like it came out of your Grandma's kitchen. That means real ingredients and no cutting corners. When a recipe can be made gluten-free and still taste like itself, we do it. When it cannot, we look for another way to make it work for people with dietary needs.</p>
+<h2>The Ones That Translate</h2>
+<p>Lemon Cake was the easy one. The recipe is Grandma Elbach's, and it took to a blend of gluten-free flour, almond flour, and corn starch without losing anything. The lemon does the rest, and the cake is naturally dairy-free too. You can see it on <a href="/products/lemon-cake.html">our lemon cake page</a>.</p>
+<p>A lot of our cakes work this way. <a href="/products/german-cheesecake.html">German Cheesecake</a>, <em>Donauwelle</em>, the summer sheet cakes. When a swap works, you will not taste the difference, because we would not sell it if you could.</p>
+<h2>The Ones We Will Not Force</h2>
+<p>Apple Strudel is the example I always give. The dough has to be rolled out paper-thin, and gluten is what holds it together. Without it, you do not get strudel, you get something else. So it is not gluten-free, and we will not pretend it is.</p>
+<p>But we did not stop there. The strudel is vegan instead. The filling uses dairy-free butter and gluten-free bread crumbs. We could not make it work for one dietary need, so we made it work for another.</p>
+<h2>Still Working on It</h2>
+<p>There is one cake I keep coming back to. Sand Cake, also called the Mimi-Cake. It is a simple pound cake, and it sounds easy until you try to make it without gluten. We have tried, and we have not gotten it right yet. So it is not on our menu, and it will not be until we do.</p>
+<p>I would rather leave a cake off the menu than sell a version I am not proud of.</p>
+<h2>Find the Ones That Work</h2>
+<p>Most of what we bring to the market is gluten-free. Come taste the difference at <a href="/index.html#find-us">one of our markets</a> or <a href="mailto:info@germanbakingasheville.com">email us</a> and we will help you find the right cake.</p></div>
           
           <div class="share-bar" aria-label="Share this article">
   <div class="share-bar__buttons">
     <span class="share-bar__label">Share</span>
-    <a href="https://twitter.com/intent/tweet?text=Kaffee%20und%20Kuchen%3A%20The%20German%20Coffee%20and%20Cake%20Tradition%20%28And%20Why%20Our%20Bakery%20Is%20Named%203pm%29&url=https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
+    <a href="https://twitter.com/intent/tweet?text=Why%20We%20Don%27t%20Make%20Everything%20Gluten-Free&url=https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html"
        class="share-bar__button share-bar__button--twitter"
        target="_blank"
        rel="noopener noreferrer"
@@ -213,7 +202,7 @@
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
       </svg>
     </a>
-    <a href="https://www.facebook.com/sharer/sharer.php?u=https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html"
        class="share-bar__button share-bar__button--facebook"
        target="_blank"
        rel="noopener noreferrer"
@@ -223,17 +212,7 @@
       </svg>
     </a>
     
-      <a href="https://pinterest.com/pin/create/button/?url=https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html&description=Kaffee%20und%20Kuchen%3A%20The%20German%20Coffee%20and%20Cake%20Tradition%20%28And%20Why%20Our%20Bakery%20Is%20Named%203pm%29&media=https://germanbakingasheville.com/images/3pm-german-baking-68.jpg"
-         class="share-bar__button share-bar__button--pinterest"
-         target="_blank"
-         rel="noopener noreferrer"
-         aria-label="Pin on Pinterest">
-        <svg viewBox="0 0 24 24" fill="currentColor">
-          <path d="M12 0C5.372 0 0 5.373 0 12c0 5.084 3.163 9.426 7.627 11.174-.105-.949-.2-2.405.042-3.442.218-.935 1.407-5.965 1.407-5.965s-.359-.719-.359-1.782c0-1.668.967-2.914 2.17-2.914 1.023 0 1.517.768 1.517 1.688 0 1.029-.655 2.568-.993 3.992-.282 1.195.597 2.168 1.775 2.168 2.13 0 3.768-2.247 3.768-5.488 0-2.87-2.061-4.876-5.007-4.876-3.41 0-5.41 2.558-5.41 5.202 0 1.027.395 2.132.89 2.732a.36.36 0 01.082.344c-.09.377-.293 1.193-.332 1.36-.053.218-.174.264-.4.159-1.492-.694-2.424-2.875-2.424-4.628 0-3.77 2.737-7.233 7.892-7.233 4.144 0 7.365 2.953 7.365 6.9 0 4.119-2.595 7.434-6.198 7.434-1.21 0-2.348-.629-2.737-1.372 0 0-.599 2.281-.744 2.84-.27 1.039-1 2.34-1.487 3.135A11.948 11.948 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0z" />
-        </svg>
-      </a>
-    
-    <a href="mailto:?subject=Kaffee%20und%20Kuchen%3A%20The%20German%20Coffee%20and%20Cake%20Tradition%20%28And%20Why%20Our%20Bakery%20Is%20Named%203pm%29&body=https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html"
+    <a href="mailto:?subject=Why%20We%20Don%27t%20Make%20Everything%20Gluten-Free&body=https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html"
        class="share-bar__button share-bar__button--email"
        aria-label="Share via email">
       <svg viewBox="0 0 24 24"
@@ -288,8 +267,8 @@
 (function() {
   var copyBtn = document.querySelector('.share-bar__button--copy');
   var nativeBtn = document.querySelector('.share-bar__button--native');
-  var url = 'https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html';
-  var title = "Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)";
+  var url = 'https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html';
+  var title = "Why We Don\u0027t Make Everything Gluten-Free";
 
   if (navigator.share) {
     nativeBtn.style.display = '';

--- a/content/blog/2026-07-25-why-3pm-kaffee-und-kuchen.md
+++ b/content/blog/2026-07-25-why-3pm-kaffee-und-kuchen.md
@@ -1,11 +1,11 @@
 ---
-title: Why 3pm? The Kaffee und Kuchen Tradition Behind Our Name
+title: "Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)"
 date: 2026-07-25
 slug: why-3pm-kaffee-und-kuchen
 author: William
-excerpt: Our bakery is named 3pm German Baking. There is a reason for that, it marks the time of Kaffee und Kuchen, the German coffee and cake tradition that most Americans have never heard of.
+excerpt: Kaffee und Kuchen is the German afternoon tradition of coffee and cake — a daily ritual at 3pm that most Americans have never heard of. It's why our bakery is named 3pm, and it shaped the lighter, less-sweet style of German baking.
 meta_description: What is Kaffee und Kuchen? Learn about the German coffee-and-cake tradition, why 3pm is the time for it, and how it shaped the lighter style of German baking at 3pm German Baking in Asheville, NC.
-page_title: "Kaffee und Kuchen: The German Coffee Cake Tradition | 3pm German Baking Blog"
+page_title: "Kaffee und Kuchen: The German Coffee and Cake Tradition | 3pm German Baking Blog"
 image: 3pm-german-baking-68.jpg
 ---
 

--- a/feed.xml
+++ b/feed.xml
@@ -5,13 +5,39 @@
     <link>https://germanbakingasheville.com/blog/</link>
     <description>German baking traditions, Asheville food culture, and stories from our micro bakery in Western North Carolina.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Aug 2026 20:59:59 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 11 Aug 2026 21:09:47 +0000</lastBuildDate>
     <atom:link href="https://germanbakingasheville.com/feed.xml" rel="self" type="application/rss+xml"/>
     <image>
       <url>https://germanbakingasheville.com/images/logo.png</url>
       <title>3pm German Baking Blog</title>
       <link>https://germanbakingasheville.com/blog/</link>
     </image>
+    
+    <item>
+      <title>Why We Don&#39;t Make Everything Gluten-Free</title>
+      <link>https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html</link>
+      <guid isPermaLink="true">https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html</guid>
+      <pubDate>Sun, 09 Aug 2026 00:00:00 +0000</pubDate>
+      <author>mary@germanbakingasheville.com (Mary)</author>
+      
+      
+      <description><![CDATA[<h2>The Question We Hear</h2>
+<p>Customers ask at the market whether our cakes are gluten-free. It is a fair question, and a lot of people in Asheville eat that way. The honest answer is that some of our cakes are and some are not.</p>
+<p>We have tried to make them all gluten-free. Some recipes translate and some do not. We will not force one just to put a label on it.</p>
+<h2>Made Like It Was in Grandma's Kitchen</h2>
+<p>We want everything we bake to feel hand-made and small-batch, like it came out of your Grandma's kitchen. That means real ingredients and no cutting corners. When a recipe can be made gluten-free and still taste like itself, we do it. When it cannot, we look for another way to make it work for people with dietary needs.</p>
+<h2>The Ones That Translate</h2>
+<p>Lemon Cake was the easy one. The recipe is Grandma Elbach's, and it took to a blend of gluten-free flour, almond flour, and corn starch without losing anything. The lemon does the rest, and the cake is naturally dairy-free too. You can see it on <a href="/products/lemon-cake.html">our lemon cake page</a>.</p>
+<p>A lot of our cakes work this way. <a href="/products/german-cheesecake.html">German Cheesecake</a>, <em>Donauwelle</em>, the summer sheet cakes. When a swap works, you will not taste the difference, because we would not sell it if you could.</p>
+<h2>The Ones We Will Not Force</h2>
+<p>Apple Strudel is the example I always give. The dough has to be rolled out paper-thin, and gluten is what holds it together. Without it, you do not get strudel, you get something else. So it is not gluten-free, and we will not pretend it is.</p>
+<p>But we did not stop there. The strudel is vegan instead. The filling uses dairy-free butter and gluten-free bread crumbs. We could not make it work for one dietary need, so we made it work for another.</p>
+<h2>Still Working on It</h2>
+<p>There is one cake I keep coming back to. Sand Cake, also called the Mimi-Cake. It is a simple pound cake, and it sounds easy until you try to make it without gluten. We have tried, and we have not gotten it right yet. So it is not on our menu, and it will not be until we do.</p>
+<p>I would rather leave a cake off the menu than sell a version I am not proud of.</p>
+<h2>Find the Ones That Work</h2>
+<p>Most of what we bring to the market is gluten-free. Come taste the difference at <a href="/index.html#find-us">one of our markets</a> or <a href="mailto:info@germanbakingasheville.com">email us</a> and we will help you find the right cake.</p>]]></description>
+    </item>
     
     <item>
       <title>What Germans Actually Eat for Their Birthdays</title>
@@ -42,7 +68,7 @@
     </item>
     
     <item>
-      <title>Why 3pm? The Kaffee und Kuchen Tradition Behind Our Name</title>
+      <title>Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)</title>
       <link>https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html</link>
       <guid isPermaLink="true">https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html</guid>
       <pubDate>Sat, 25 Jul 2026 00:00:00 +0000</pubDate>

--- a/index.html
+++ b/index.html
@@ -1428,13 +1428,51 @@
             <div class="blog-recent__grid">
               
                 <article class="blog-card">
+  <a href="blog/why-we-dont-make-everything-gluten-free.html" class="blog-card__link">
+    
+    <div class="blog-card__content">
+      <div class="blog-card__meta">
+        <time class="blog-card__date" datetime="2026-08-09">August 09, 2026</time>
+        
+          <span class="blog-card__separator">·</span>
+          <span class="blog-card__author">Mary</span>
+        
+        <span class="blog-card__separator">·</span>
+        <span class="blog-card__reading-time">3 min read</span>
+      </div>
+      <h3 class="blog-card__title">Why We Don&#39;t Make Everything Gluten-Free</h3>
+      <p class="blog-card__excerpt">Some of our cakes are gluten-free and some are not. That is a choice. We will not compromise what makes a German cake good just to put a label on it.</p>
+    </div>
+  </a>
+</article>
+              
+                <article class="blog-card">
+  <a href="blog/german-birthday-cakes.html" class="blog-card__link">
+    
+    <div class="blog-card__content">
+      <div class="blog-card__meta">
+        <time class="blog-card__date" datetime="2026-08-02">August 02, 2026</time>
+        
+          <span class="blog-card__separator">·</span>
+          <span class="blog-card__author">Mary</span>
+        
+        <span class="blog-card__separator">·</span>
+        <span class="blog-card__reading-time">2 min read</span>
+      </div>
+      <h3 class="blog-card__title">What Germans Actually Eat for Their Birthdays</h3>
+      <p class="blog-card__excerpt">A customer in Asheville asked for a chocolate birthday cake. I knew the one. But it got me thinking about how German birthdays are different here, starting with the fact that you are expected to bring your own cake.</p>
+    </div>
+  </a>
+</article>
+              
+                <article class="blog-card">
   <a href="blog/why-3pm-kaffee-und-kuchen.html" class="blog-card__link">
     
       <div class="blog-card__image">
         <picture>
           <source srcset="images/3pm-german-baking-68.jpg" type="image/webp">
           <img src="images/3pm-german-baking-68.jpg"
-               alt="Why 3pm? The Kaffee und Kuchen Tradition Behind Our Name"
+               alt="Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)"
                loading="lazy"
                width="800"
                height="533">
@@ -1451,68 +1489,8 @@
         <span class="blog-card__separator">·</span>
         <span class="blog-card__reading-time">2 min read</span>
       </div>
-      <h3 class="blog-card__title">Why 3pm? The Kaffee und Kuchen Tradition Behind Our Name</h3>
-      <p class="blog-card__excerpt">Our bakery is named 3pm German Baking. There is a reason for that, it marks the time of Kaffee und Kuchen, the German coffee and cake tradition that most Americans have never heard of.</p>
-    </div>
-  </a>
-</article>
-              
-                <article class="blog-card">
-  <a href="blog/bakery-lightning-talk-scipy-2026.html" class="blog-card__link">
-    
-      <div class="blog-card__image">
-        <picture>
-          <source srcset="images/scipy-talk.jpg" type="image/webp">
-          <img src="images/scipy-talk.jpg"
-               alt="William presenting a lightning talk at SciPy 2026."
-               loading="lazy"
-               width="800"
-               height="533">
-        </picture>
-      </div>
-    
-    <div class="blog-card__content">
-      <div class="blog-card__meta">
-        <time class="blog-card__date" datetime="2026-07-17">July 17, 2026</time>
-        
-          <span class="blog-card__separator">·</span>
-          <span class="blog-card__author">William</span>
-        
-        <span class="blog-card__separator">·</span>
-        <span class="blog-card__reading-time">3 min read</span>
-      </div>
-      <h3 class="blog-card__title">What a Bakery Taught Data Scientists About Practical Technology</h3>
-      <p class="blog-card__excerpt">I had five minutes at SciPy 2026 to tell a room full of data scientists what it is like running a two-person German bakery with open-source technology. The response surprised me.</p>
-    </div>
-  </a>
-</article>
-              
-                <article class="blog-card">
-  <a href="blog/six-months-at-market-asheville-home.html" class="blog-card__link">
-    
-      <div class="blog-card__image">
-        <picture>
-          <source srcset="images/black-mountain-first-season-end.jpeg" type="image/webp">
-          <img src="images/black-mountain-first-season-end.jpeg"
-               alt="William and Mary at their 3pm German Baking market stand at the Black Mountain Tailgate Market in Asheville, NC."
-               loading="lazy"
-               width="800"
-               height="533">
-        </picture>
-      </div>
-    
-    <div class="blog-card__content">
-      <div class="blog-card__meta">
-        <time class="blog-card__date" datetime="2026-07-01">July 01, 2026</time>
-        
-          <span class="blog-card__separator">·</span>
-          <span class="blog-card__author">William</span>
-        
-        <span class="blog-card__separator">·</span>
-        <span class="blog-card__reading-time">3 min read</span>
-      </div>
-      <h3 class="blog-card__title">How Six Months at the Market Made Asheville Feel Like Home</h3>
-      <p class="blog-card__excerpt">We moved to Asheville not knowing anyone. Six months of running a bakery at the farmers market changed the way we connect with this city.</p>
+      <h3 class="blog-card__title">Kaffee und Kuchen: The German Coffee and Cake Tradition (And Why Our Bakery Is Named 3pm)</h3>
+      <p class="blog-card__excerpt">Kaffee und Kuchen is the German afternoon tradition of coffee and cake — a daily ritual at 3pm that most Americans have never heard of. It&#39;s why our bakery is named 3pm, and it shaped the lighter, less-sweet style of German baking.</p>
     </div>
   </a>
 </article>

--- a/products/german-cheesecake.html
+++ b/products/german-cheesecake.html
@@ -206,6 +206,10 @@
               <ul>
                 
                   <li>
+                    <a href="../blog/why-we-dont-make-everything-gluten-free.html">Why We Don&#39;t Make Everything Gluten-Free</a>
+                  </li>
+                
+                  <li>
                     <a href="../blog/what-is-quark.html">What Is Quark? The German Ingredient I Learned About the Hard Way</a>
                   </li>
                 

--- a/products/lemon-cake.html
+++ b/products/lemon-cake.html
@@ -194,6 +194,17 @@
             </section>
           
           
+            <section class="product-detail__section">
+              <h2>Related Blog Posts</h2>
+              <ul>
+                
+                  <li>
+                    <a href="../blog/why-we-dont-make-everything-gluten-free.html">Why We Don&#39;t Make Everything Gluten-Free</a>
+                  </li>
+                
+              </ul>
+            </section>
+          
           <!-- Where to Buy / Wholesale CTA -->
           <section class="product-detail__section">
             <h2>Where to Buy</h2>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -25,55 +25,55 @@
   <!-- PRODUCT_START -->
   <url>
     <loc>https://germanbakingasheville.com/products/almond-ricotta-cake.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/german-cheesecake.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/lemon-cake.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/oma-christas-spiced-cake.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/pudding-powder.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/russian-pull-cake.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/seasonal-vegetable-quiche.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/spinach-tartlets.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/products/vanilla-sugar.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -81,61 +81,73 @@
   <!-- BLOG_START -->
   <url>
     <loc>https://germanbakingasheville.com/blog/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://germanbakingasheville.com/blog/why-we-dont-make-everything-gluten-free.html</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://germanbakingasheville.com/blog/german-birthday-cakes.html</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://germanbakingasheville.com/blog/why-3pm-kaffee-und-kuchen.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/bakery-lightning-talk-scipy-2026.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/six-months-at-market-asheville-home.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/meet-wright-open-source-engine.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/custom-cake-orders.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/automated-grocery-lists.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/how-north-asheville-market-started-our-bakery.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/why-we-make-vanilla-sugar-and-pudding-powder.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://germanbakingasheville.com/blog/what-is-quark.html</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
Improves SEO for the Kaffee und Kuchen blog post based on Search Console data showing 239 impressions at 0.4% CTR.

- **H1**: Lead with Kaffee und Kuchen instead of Why 3pm? — matches what people search
- **Page title**: Fix Coffee Cake → Coffee and Cake (American coffee cake is a different food)
- **Excerpt**: Describe the tradition upfront
- **Slug unchanged**: No redirects needed